### PR TITLE
Add tracking for browsers, platforms and referrers to DB

### DIFF
--- a/shrunk/client.py
+++ b/shrunk/client.py
@@ -599,7 +599,7 @@ class ShrunkClient(object):
         cursor = db.urls.find(query)
         return ShrunkCursor(cursor)
 
-    def visit(self, short_url, source_ip):
+    def visit(self, short_url, source_ip, platform, browser, referrer):
         """Visits the given URL and logs visit information.
 
         On visiting a URL, this is guaranteed to perform at least the following
@@ -618,11 +618,13 @@ class ShrunkClient(object):
         db.urls.update({"_id" : short_url},
                        {"$inc" : {"visits" : 1}})
 
-        # TODO Scan source IP against Rutgers subnets.
         db = self._mongo.shrunk_visits
         db.visits.insert({
             "short_url" : short_url,
             "source_ip" : source_ip,
+            "platform" : platform,
+            "referrer" : referrer,
+            "browser" : browser,
             "time" : datetime.datetime.now()
         })
 

--- a/shrunk/linkserver.py
+++ b/shrunk/linkserver.py
@@ -42,7 +42,11 @@ def redirect_link(short_url):
     if long_url is None:
         return render_template("link-404.html", short_url=short_url)
     else:
-        client.visit(short_url, request.remote_addr)
+        client.visit(short_url = short_url, 
+                     source_ip = request.remote_addr,
+                     platform = request.user_agent.platform,
+                     browser = request.user_agent.browser,
+                     referrer = shrunk.util.get_domain(request.referrer))
 
         # Check if a protocol exists
         if "://" in long_url:

--- a/shrunk/util.py
+++ b/shrunk/util.py
@@ -5,6 +5,7 @@
 import logging
 
 from shrunk.client import ShrunkClient
+from urllib.parse import urlsplit
 
 
 def get_db_client(app, g):
@@ -44,3 +45,23 @@ def formattime(datetime):
     This formats datetimes to look like "Nov 19 2015".
     """
     return datetime.strftime("%b %d %Y")
+
+
+def get_domain(uri):
+    """Utility function to grab domain from URL.
+
+    Used in application to extract referrer names from requests.
+    """
+    if uri is None:
+        return "unknown"
+    try:
+        parsed_uri = urlsplit(uri)
+        domain = '{0.netloc}'.format(parsed_uri)
+        split = domain.split('.')
+        if len(split) >= 2:
+            domain = split[-2]
+        else:
+            domain = "unknown"
+        return domain
+    except:
+        return "unknown"


### PR DESCRIPTION
We want to implement a stats view similar to goo.gl. Before, upon any
request, only the source_ip was being tracked for those accessing a URL. 
Now, browsers, platforms and referrers are being tracked and added to
the MongoDB instance. Domain names are extracted with a get_domain()
function in util.py. The DB client visit() method was updated to add
this new information, and this new information was extracted from the
request objects in both appserver.py and linkserver.py.
